### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,9 @@ name: Go
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/rijdendetreinen/gotrain/security/code-scanning/3](https://github.com/rijdendetreinen/gotrain/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the minimal permissions required for the workflow to function. Based on the steps in the workflow, the `contents: read` permission is sufficient, as the workflow only checks out code, installs dependencies, builds, and runs tests. No write permissions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
